### PR TITLE
Set CultureInfo.InvariantCulture as default

### DIFF
--- a/BmsPreviewAudioGenerator/Program.cs
+++ b/BmsPreviewAudioGenerator/Program.cs
@@ -8,10 +8,12 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace BmsPreviewAudioGenerator
 {
@@ -26,6 +28,9 @@ namespace BmsPreviewAudioGenerator
 
         static void Main(string[] args)
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             Console.WriteLine($"Program version:{typeof(Program).Assembly.GetName().Version}");
 
             if (!Bass.Init())


### PR DESCRIPTION
Some BMS files contain lines like `#10302:0.5`, where 0.5 is a decimal number. If the system locale uses a comma `,` as the decimal separator, 0.5 will be parsed as 5, resulting in broken preview files, either completely muted or missing a few sounds.

![image](https://user-images.githubusercontent.com/4316326/162052488-f485ea6a-6f6a-4216-898c-a9d8b7a2961f.png)

This issue can be easily reproduced with the following code snippet.
```
using System;
using System.Globalization;
					
public class Program
{
	public static void Main()
	{
		var locale = new CultureInfo("pt-BR"); // brazilian portuguese
		var value = decimal.Parse("0.5", locale);
		
		Console.WriteLine(value); // will output 5 instead of 0.5
	}
}
```

This pull request is just a band-aid fix as it's actually not good practice to mess with `Thread.CurrentThread` directly. A better approach would be to pass `CultureInfo.InvariantCulture` to every call to `decimal.Parse`, `float.Parse`, etc., but then we would need to fix [Bemusilization](https://github.com/MikiraSora/Bemusilization), [csbms-parser](https://github.com/MikiraSora/csbms-parser) and every other external dependency as well.

```
using System;
using System.Globalization;
					
public class Program
{
	public static void Main()
	{
		var locale = CultureInfo.InvariantCulture;
		var value = decimal.Parse("0.5", locale);
		
		Console.WriteLine(value); // will output 0.5
	}
}
```