### PR TITLE
Set console encoding to UTF8.

### DIFF
--- a/BmsPreviewAudioGenerator/Program.cs
+++ b/BmsPreviewAudioGenerator/Program.cs
@@ -46,6 +46,8 @@ namespace BmsPreviewAudioGenerator
 
         static void Main(string[] args)
         {
+            Console.OutputEncoding = Encoding.UTF8;
+
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);


### PR DESCRIPTION
此消息由英文自动翻译而来，如有不当之处，请见谅。

此更改将控制台输出编码设置为 UTF-8。
在英文语言环境下，这修复了非 ASCII 字符会显示为 ? 的问题。

以下是在更改之前的示例：
<img width="1115" height="628" alt="utf8-before" src="https://github.com/user-attachments/assets/558336bc-992f-4cbe-88e2-61b7bf40356c" />

以下是在应用更改之后的示例：
<img width="1115" height="628" alt="utf8-after" src="https://github.com/user-attachments/assets/66b7f3a3-8ac5-4bd9-ad9e-1b2ef50413d7" />

These changes set the console output encoding to UTF-8. For English locales this corrects an issue where non-ASCII characters would render as `?`.

Here is an example from before these changes:
<img width="1115" height="628" alt="utf8-before" src="https://github.com/user-attachments/assets/558336bc-992f-4cbe-88e2-61b7bf40356c" />

Here is an example from after these changes:
<img width="1115" height="628" alt="utf8-after" src="https://github.com/user-attachments/assets/66b7f3a3-8ac5-4bd9-ad9e-1b2ef50413d7" />
